### PR TITLE
The gaussianization function will now apply to all proxies.

### DIFF
--- a/LMR_proxy_preprocess.py
+++ b/LMR_proxy_preprocess.py
@@ -845,7 +845,7 @@ def colonReader(string, fCon, fCon_low, end):
 
 # ===================================================================================
 
-def read_proxy_data_NCDCtxt(site, proxy_def, year_type=None):
+def read_proxy_data_NCDCtxt(site, proxy_def, year_type=None, gaussianize_data=False):
 #====================================================================================
 # Purpose: Reads data from a selected site (chronology) in NCDC proxy dataset
 # 
@@ -1449,6 +1449,11 @@ def read_proxy_data_NCDCtxt(site, proxy_def, year_type=None):
         # If subannual, average up to annual --------------------------------------------------------
         time_annual, data_annual, proxy_resolution = compute_annual_means(time_raw,data_raw,valid_frac,year_type)
         
+        # If gaussianize_data is set to true, transform the proxy data to Gaussian.
+        # This option should only be used when using regressions, not physically-based PSMs.
+        if gaussianize_data == True:
+            data_annual = gaussianize(data_annual)
+        
         # update to yearRange given availability of annual data
         yearRange = (int('%.0f' %time_annual[0]),int('%.0f' %time_annual[-1]))
         
@@ -1552,7 +1557,7 @@ def ncdc_txt_to_dict(datadir, proxy_def, year_type, gaussianize_data):
     nbsites_valid = 0
     for file_site in sites_data:
 
-        proxy_list, duplicate_list = read_proxy_data_NCDCtxt(file_site,proxy_def,year_type)
+        proxy_list, duplicate_list = read_proxy_data_NCDCtxt(file_site,proxy_def,year_type,gaussianize_data)
 
         if proxy_list: # if returned list is not empty
             # extract data from list and populate the master proxy dictionary

--- a/LMR_utils.py
+++ b/LMR_utils.py
@@ -1276,21 +1276,46 @@ def gaussianize(X):
 
     """
 
-    #n = X.shape[0]
-    n = X[~np.isnan(X)].shape[0]  # This line counts only elements with data.
+    # Give every record at least one dimensions, or else the code will crash.
+    X = np.atleast_1d(X)
 
-    #Xn = np.empty((n,))
-    Xn = copy.deepcopy(X)  # This line retains the data type of the original data variable.
+    # Make a blank copy of the array, retaining the data type of the original data variable.
+    Xn = copy.deepcopy(X)
     Xn[:] = np.NAN
-    nz = np.logical_not(np.isnan(X))
 
-    index = np.argsort(X[nz])
+    if len(X.shape) == 1:
+        Xn = gaussianize_single(X)
+    else:
+        for i in range(X.shape[1]):
+            Xn[:,i] = gaussianize_single(X[:,i])
+
+    return Xn
+
+
+def gaussianize_single(X_single):
+    """
+    Transforms a single (proxy) timeseries to Gaussian distribution.
+
+    Originator: Michael Erb, Univ. of Southern California - April 2017
+
+    """
+
+    # Count only elements with data.
+    n = X_single[~np.isnan(X_single)].shape[0]
+
+    # Create a blank copy of the array.
+    Xn_single = copy.deepcopy(X_single)
+    Xn_single[:] = np.NAN
+
+    nz = np.logical_not(np.isnan(X_single))
+
+    index = np.argsort(X_single[nz])
     rank = np.argsort(index)
 
     CDF = 1.*(rank+1)/(1.*n) -1./(2*n)
-    Xn[nz] = np.sqrt(2)*special.erfinv(2*CDF -1)
+    Xn_single[nz] = np.sqrt(2)*special.erfinv(2*CDF -1)
 
-    return Xn
+    return Xn_single
 
 
 def validate_config(config):


### PR DESCRIPTION
The LMR_proxy_preprocess.py and LMR_utils.py scripts have been modified to apply the gaussianization option to all proxies, not just the PAGES2k proxies.  Since some NCDC records have more than one records (i.e. the data is in a 2D array), the gaussianization function in LMR_utils.py had to be updated to handle this.