### PR TITLE
Add mgca psm

### DIFF
--- a/LMR_psms.py
+++ b/LMR_psms.py
@@ -66,7 +66,11 @@ try:
     import deltaoxfox as dfox
 except ImportError as e3:
     print('Warning:', e3)
-    
+try:
+    import baymag
+except ImportError as e3:
+    print('Warning:', e3)
+
 
 # Logging output utility, configuration controlled by driver
 _log = logging.getLogger(__name__)
@@ -2009,6 +2013,185 @@ class BayesRegD18oPachydermaPSM(BayesRegD18oPSM):
         self.psm_key = 'bayesreg_d18o_pachyderma'
 
 
+@class_docs_fixer
+class BayesRegMgcaPSM(BayesRegPSM):
+    """
+    ...
+
+    Attributes
+    ----------
+
+    ...
+
+    lat: float
+        Latitude of associated proxy site
+    lon: float
+        Longitude of associated proxy site
+    elev: float
+        Elevation/depth of proxy site
+    R: float
+        Obs. error variance associated to proxy site
+
+    Parameters
+    ----------
+    config: LMR_config
+        Configuration module used for current LMR run.
+    proxy_obj: BaseProxyObject like
+        Proxy object that this PSM is being attached to.
+
+    Raises
+    ------
+    ValueError
+        ...
+    """
+
+    def __init__(self, config, proxy_obj, spp, cleaning):
+        super().__init__(config, proxy_obj)
+        self.psm_key = 'bayesreg_mgca'
+        self.sensitivity = 'sst'  # TODO(brews): Also need 'sss'?
+        self.psm_required_variables = config.psm.bayesreg_mgca.psm_required_variables
+        self.spp = str(spp)
+        self.cleaning = np.array(cleaning)
+
+        self.R = self._estimate_r(15, 16)  # This is temporary. Should consider wider range.
+
+    def _estimate_r(self, *args, **kwargs):
+        """Fit Bayes regression to range of input values and return max variance
+        """
+        xrange = np.arange(*args, **kwargs)
+
+        # This assumes that changes in salinity will not influence ensemble variance.
+        ensemble = self._mcmc_predict(sst=xrange)
+        return np.max(np.var(ensemble, axis=1))
+
+    def _mcmc_predict(self, sst):
+        """Get MCMC ensemble prediction for input variables
+        """
+        # Longitude is often over 180.
+        lon = float(self.lon)
+        if lon > 180:
+            lon -= 360
+
+        depth = np.abs(self.elev)  # `baymag` wants depth needs to be positive.
+
+        y = baymag.predict_mgca(seatemp=sst, spp=self.spp, latlon=(self.lat, lon),
+                                depth=depth, cleaning=self.cleaning,
+                                distance_threshold=30000)
+
+        return y.ensemble
+
+    def psm(self, Xb, X_state_info, X_coords):
+        """
+        Maps a given state to observations for the given proxy
+
+        Parameters
+        ----------
+        Xb: ndarray
+            State vector to be mapped into observation space (stateDim x ensDim)
+        X_state_info: dict
+            Information pertaining to variables in the state vector
+        X_coords: ndarray
+            Coordinates for the state vector (stateDim x 2)
+
+        Returns
+        -------
+        Ye:
+            Equivalent observation from prior
+        """
+
+        # ----------------------
+        # Calculate the Ye's ...
+        # ----------------------
+
+        # Defining state variables to consider in the calculation of Ye's
+        #
+        for state_var in list(self.psm_required_variables.keys()):
+            if state_var not in list(X_state_info.keys()):
+                raise KeyError('Needed variable not in state vector for Ye calculation.')
+
+        xb_sst = self._get_gridpoint_data('tos_sfc_Odec', Xb, X_state_info, X_coords)
+
+        # check if gridpoint_data is in K: need deg. C for forward model
+        # crude check...
+        if np.nanmin(xb_sst) > 200.0:
+            xb_sst = xb_sst - 273.15
+
+        ye_ens = self._mcmc_predict(xb_sst)
+        ye = np.mean(ye_ens, axis=1)
+        return ye
+
+    # Define a default error model for this proxy
+    @staticmethod
+    def error():
+        return 0.1
+
+# Define specific classes 'foram type':'sample cleaning' combinations for Mg/Ca proxies.
+# Might do better as a class factory in the future.
+
+@class_docs_fixer
+class BayesRegMgcaRuberwhiteRedPSM(BayesRegMgcaPSM):
+    def __init__(self, config, proxy_obj):
+        # Mg/Ca for ruber white with fully reductive sample cleaning
+        super().__init__(config, proxy_obj, 'ruber_w', cleaning=1)
+        self.psm_key = 'bayesreg_mgca_ruberwhite_red'
+
+
+@class_docs_fixer
+class BayesRegMgcaRuberwhiteBcpPSM(BayesRegMgcaPSM):
+    def __init__(self, config, proxy_obj):
+        # Mg/Ca for ruber white with Barker sample cleaning protocol
+        super().__init__(config, proxy_obj, 'ruber_w', cleaning=0)
+        self.psm_key = 'bayesreg_mgca_ruberwhite_bcp'
+
+
+@class_docs_fixer
+class BayesRegMgcaSacculiferRedPSM(BayesRegMgcaPSM):
+    def __init__(self, config, proxy_obj):
+        # Mg/Ca for sacculifer with fully reductive sample cleaning
+        super().__init__(config, proxy_obj, 'sacculifer', cleaning=1)
+        self.psm_key = 'bayesreg_mgca_sacculifer_red'
+
+
+@class_docs_fixer
+class BayesRegMgcaSacculiferBcpPSM(BayesRegMgcaPSM):
+    def __init__(self, config, proxy_obj):
+        # Mg/Ca for sacculifer with Barker sample cleaning protocol
+        super().__init__(config, proxy_obj, 'sacculifer', cleaning=0)
+        self.psm_key = 'bayesreg_mgca_sacculifer_bcp'
+
+
+@class_docs_fixer
+class BayesRegMgcaBulloidesRedPSM(BayesRegMgcaPSM):
+    def __init__(self, config, proxy_obj):
+        # Mg/Ca for bulloides with fully reductive sample cleaning
+        super().__init__(config, proxy_obj, 'bulloides', cleaning=1)
+        self.psm_key = 'bayesreg_mgca_bulloides_red'
+
+
+@class_docs_fixer
+class BayesRegMgcaBulloidesBcpPSM(BayesRegMgcaPSM):
+    def __init__(self, config, proxy_obj):
+        # Mg/Ca for bulloides with Barker sample cleaning protocol
+        super().__init__(config, proxy_obj, 'bulloides', cleaning=0)
+        self.psm_key = 'bayesreg_mgca_bulloides_bcp'
+
+
+@class_docs_fixer
+class BayesRegMgcaPachydermaRedPSM(BayesRegMgcaPSM):
+    def __init__(self, config, proxy_obj):
+        # Mg/Ca for pachyderma sinistral with fully reductive sample cleaning
+        super().__init__(config, proxy_obj, 'pachy_s', cleaning=1)
+        self.psm_key = 'bayesreg_mgca_pachyderma_red'
+
+
+@class_docs_fixer
+class BayesRegMgcaPachydermaBcpPSM(BayesRegMgcaPSM):
+    def __init__(self, config, proxy_obj):
+        # Mg/Ca for pachyderma sinistral with Barker sample cleaning protocol
+        super().__init__(config, proxy_obj, 'pachy_s', cleaning=0)
+        self.psm_key = 'bayesreg_mgca_pachyderma_bcp'
+
+
 # Mapping dict to PSM object type, this is where proxy_type/psm relations
 # should be specified (I think.) - AP
 _psm_classes = {'linear': LinearPSM, 'linear_TorP': LinearPSM_TorP,
@@ -2017,7 +2200,16 @@ _psm_classes = {'linear': LinearPSM, 'linear_TorP': LinearPSM_TorP,
                 'bayesreg_d18o_pachyderma': BayesRegD18oPachydermaPSM,
                 'bayesreg_d18o_bulloides': BayesRegD18oBulloidesPSM,
                 'bayesreg_d18o_sacculifer': BayesRegD18oSacculiferPSM,
-                'bayesreg_d18o_ruberwhite': BayesRegD18oRuberwhitePSM}
+                'bayesreg_d18o_ruberwhite': BayesRegD18oRuberwhitePSM,
+                'bayesreg_mgca_ruberwhite_red': BayesRegMgcaRuberwhiteRedPSM,
+                'bayesreg_mgca_ruberwhite_bcp': BayesRegMgcaRuberwhiteBcpPSM,
+                'bayesreg_mgca_sacculifer_red': BayesRegMgcaSacculiferRedPSM,
+                'bayesreg_mgca_sacculifer_bcp': BayesRegMgcaSacculiferBcpPSM,
+                'bayesreg_mgca_bulloides_red': BayesRegMgcaBulloidesRedPSM,
+                'bayesreg_mgca_bulloides_bcp': BayesRegMgcaBulloidesBcpPSM,
+                'bayesreg_mgca_pachyderma_red': BayesRegMgcaPachydermaRedPSM,
+                'bayesreg_mgca_pachyderma_bcp': BayesRegMgcaPachydermaBcpPSM,
+                }
 
 
 def get_psm_class(psm_type):

--- a/LMR_psms.py
+++ b/LMR_psms.py
@@ -2045,12 +2045,12 @@ class BayesRegMgcaPSM(BayesRegPSM):
         ...
     """
 
-    def __init__(self, config, proxy_obj, spp, cleaning):
+    def __init__(self, config, proxy_obj, cleaning, spp=None):
         super().__init__(config, proxy_obj)
         self.psm_key = 'bayesreg_mgca'
         self.sensitivity = 'sst'  # TODO(brews): Also need 'sss'?
         self.psm_required_variables = config.psm.bayesreg_mgca.psm_required_variables
-        self.spp = str(spp)
+        self.spp = spp
         self.cleaning = np.array(cleaning)
 
         self.R = self._estimate_r(15, 16)  # This is temporary. Should consider wider range.
@@ -2072,11 +2072,11 @@ class BayesRegMgcaPSM(BayesRegPSM):
         if lon > 180:
             lon -= 360
 
-        depth = np.abs(self.elev)  # `baymag` wants depth needs to be positive.
+        depth = np.abs(self.elev)  # `baymag` wants positive depths.
 
         y = baymag.predict_mgca(seatemp=sst, spp=self.spp, latlon=(self.lat, lon),
                                 depth=depth, cleaning=self.cleaning,
-                                distance_threshold=30000)
+                                distance_threshold=3000)
 
         return y.ensemble
 
@@ -2127,6 +2127,22 @@ class BayesRegMgcaPSM(BayesRegPSM):
 
 # Define specific classes 'foram type':'sample cleaning' combinations for Mg/Ca proxies.
 # Might do better as a class factory in the future.
+
+@class_docs_fixer
+class BayesRegMgcaPooledRedPSM(BayesRegMgcaPSM):
+    def __init__(self, config, proxy_obj):
+        # Mg/Ca for model with pooled foram species with fully reductive sample cleaning
+        super().__init__(config, proxy_obj, cleaning=1, spp=None)
+        self.psm_key = 'bayesreg_mgca_pooled_red'
+
+
+@class_docs_fixer
+class BayesRegMgcaPooledBcpPSM(BayesRegMgcaPSM):
+    def __init__(self, config, proxy_obj):
+        # Mg/Ca for model with pooled foram species with Barker sample cleaning protocol
+        super().__init__(config, proxy_obj, cleaning=1, spp=None)
+        self.psm_key = 'bayesreg_mgca_pooled_bcp'
+
 
 @class_docs_fixer
 class BayesRegMgcaRuberwhiteRedPSM(BayesRegMgcaPSM):
@@ -2209,6 +2225,8 @@ _psm_classes = {'linear': LinearPSM, 'linear_TorP': LinearPSM_TorP,
                 'bayesreg_mgca_bulloides_bcp': BayesRegMgcaBulloidesBcpPSM,
                 'bayesreg_mgca_pachyderma_red': BayesRegMgcaPachydermaRedPSM,
                 'bayesreg_mgca_pachyderma_bcp': BayesRegMgcaPachydermaBcpPSM,
+                'bayesreg_mgca_pooled_red' : BayesRegMgcaPooledRedPSM,
+                'bayesreg_mgca_pooled_bcp' : BayesRegMgcaPooledBcpPSM,
                 }
 
 

--- a/LMR_utils.py
+++ b/LMR_utils.py
@@ -1862,8 +1862,16 @@ def create_precalc_ye_filename(config,psm_key,prior_kind):
         calib_avgPeriod = ''.join([str(config.prior.avgInterval['multiyear'][0]),'yrs'])
         calib_str = ''
         state_vars_for_ye = config.psm.bayesreg_d18o.psm_required_variables
+
+    elif psm_key in ['bayesreg_mgca_pachyderma_red', 'bayesreg_mgca_pachyderma_bcp',
+                     'bayesreg_mgca_bulloides_red', 'bayesreg_mgca_bulloides_bcp',
+                     'bayesreg_mgca_sacculifer_red', 'bayesreg_mgca_sacculifer_bcp',
+                     'bayesreg_mgca_ruberwhite_red', 'bayesreg_mgca_ruberwhite_bcp']:
+        calib_avgPeriod = ''.join([str(config.prior.avgInterval['multiyear'][0]), 'yrs'])
+        calib_str = ''
+        state_vars_for_ye = config.psm.bayesreg_mgca.psm_required_variables
     else:
-        raise ValueError('Unrecognized PSM key.')
+        raise ValueError('Unrecognized PSM key: {}'.format(psm_key))
     
     if calib_avgPeriod:
         psm_str = psm_key +'_'+ calib_avgPeriod + '-' + calib_str
@@ -1941,8 +1949,13 @@ def load_precalculated_ye_vals_psm_per_proxy(config, proxy_manager, proxy_set, s
             pkind = 'full'
         elif psm_key == 'bayesreg_d18o_pachyderma':
             pkind = 'full'
+        elif psm_key in ['bayesreg_mgca_pachyderma_red', 'bayesreg_mgca_pachyderma_bcp',
+                         'bayesreg_mgca_bulloides_red', 'bayesreg_mgca_bulloides_bcp',
+                         'bayesreg_mgca_sacculifer_red', 'bayesreg_mgca_sacculifer_bcp',
+                         'bayesreg_mgca_ruberwhite_red', 'bayesreg_mgca_ruberwhite_bcp']:
+            pkind = 'full'
         else:
-            raise ValueError('Unrecognized PSM key.')
+            raise ValueError('Unrecognized PSM key: {}'.format(psm_key))
 
         load_fname = create_precalc_ye_filename(config,psm_key,pkind)
         _log.info('Loading file:' + load_fname)
@@ -2061,7 +2074,7 @@ def load_precalculated_ye_vals_psm_per_proxy_onlyobjs(config, proxy_objs, sample
         elif psm_key == 'bayesreg_uk37':
             pkind = 'full'
         else:
-            raise ValueError('Unrecognized PSM key.')
+            raise ValueError('Unrecognized PSM key: {}'.format(psm_key))
 
         load_fname = create_precalc_ye_filename(config,psm_key,pkind)
         print('  Loading file:', load_fname)

--- a/LMR_utils.py
+++ b/LMR_utils.py
@@ -1866,7 +1866,8 @@ def create_precalc_ye_filename(config,psm_key,prior_kind):
     elif psm_key in ['bayesreg_mgca_pachyderma_red', 'bayesreg_mgca_pachyderma_bcp',
                      'bayesreg_mgca_bulloides_red', 'bayesreg_mgca_bulloides_bcp',
                      'bayesreg_mgca_sacculifer_red', 'bayesreg_mgca_sacculifer_bcp',
-                     'bayesreg_mgca_ruberwhite_red', 'bayesreg_mgca_ruberwhite_bcp']:
+                     'bayesreg_mgca_ruberwhite_red', 'bayesreg_mgca_ruberwhite_bcp',
+                     'bayesreg_mgca_pooled_red', 'bayesreg_mgca_pooled_bcp']:
         calib_avgPeriod = ''.join([str(config.prior.avgInterval['multiyear'][0]), 'yrs'])
         calib_str = ''
         state_vars_for_ye = config.psm.bayesreg_mgca.psm_required_variables
@@ -1952,7 +1953,8 @@ def load_precalculated_ye_vals_psm_per_proxy(config, proxy_manager, proxy_set, s
         elif psm_key in ['bayesreg_mgca_pachyderma_red', 'bayesreg_mgca_pachyderma_bcp',
                          'bayesreg_mgca_bulloides_red', 'bayesreg_mgca_bulloides_bcp',
                          'bayesreg_mgca_sacculifer_red', 'bayesreg_mgca_sacculifer_bcp',
-                         'bayesreg_mgca_ruberwhite_red', 'bayesreg_mgca_ruberwhite_bcp']:
+                         'bayesreg_mgca_ruberwhite_red', 'bayesreg_mgca_ruberwhite_bcp',
+                         'bayesreg_mgca_pooled_red', 'bayesreg_mgca_pooled_bcp']:
             pkind = 'full'
         else:
             raise ValueError('Unrecognized PSM key: {}'.format(psm_key))

--- a/config_templs/LMR_config_template.py
+++ b/config_templs/LMR_config_template.py
@@ -1554,6 +1554,8 @@ class psm(ConfigGroup):
         self.bayesreg_mgca_bulloides_bcp = self.bayesreg_mgca
         self.bayesreg_mgca_pachyderma_red = self.bayesreg_mgca
         self.bayesreg_mgca_pachyderma_bcp = self.bayesreg_mgca
+        self.bayesreg_mgca_pooled_red = self.bayesreg_mgca
+        self.bayesreg_mgca_pooled_bcp = self.bayesreg_mgca
 
 
         super().__init__(**kwargs)

--- a/config_templs/LMR_config_template.py
+++ b/config_templs/LMR_config_template.py
@@ -1545,6 +1545,15 @@ class psm(ConfigGroup):
         self.bayesreg_d18o_ruberwhite = self.bayesreg_d18o
         self.bayesreg_d18o_bulloides = self.bayesreg_d18o
         self.bayesreg_d18o_pachyderma = self.bayesreg_d18o
+        self.bayesreg_mgca = self.bayesreg_mgca(**kwargs.pop('bayesreg_mgca', {}))
+        self.bayesreg_mgca_sacculifer_red = self.bayesreg_mgca
+        self.bayesreg_mgca_sacculifer_bcp = self.bayesreg_mgca
+        self.bayesreg_mgca_ruberwhite_red = self.bayesreg_mgca
+        self.bayesreg_mgca_ruberwhite_bcp = self.bayesreg_mgca
+        self.bayesreg_mgca_bulloides_red = self.bayesreg_mgca
+        self.bayesreg_mgca_bulloides_bcp = self.bayesreg_mgca
+        self.bayesreg_mgca_pachyderma_red = self.bayesreg_mgca
+        self.bayesreg_mgca_pachyderma_bcp = self.bayesreg_mgca
 
 
         super().__init__(**kwargs)

--- a/misc/build_ye_file.py
+++ b/misc/build_ye_file.py
@@ -203,7 +203,8 @@ def main(cfgin=None, config_path=None):
         elif psm_key in ['bayesreg_mgca_pachyderma_red', 'bayesreg_mgca_pachyderma_bcp',
                          'bayesreg_mgca_bulloides_red', 'bayesreg_mgca_bulloides_bcp',
                          'bayesreg_mgca_sacculifer_red', 'bayesreg_mgca_sacculifer_bcp',
-                         'bayesreg_mgca_ruberwhite_red', 'bayesreg_mgca_ruberwhite_bcp']:
+                         'bayesreg_mgca_ruberwhite_red', 'bayesreg_mgca_ruberwhite_bcp',
+                         'bayesreg_mgca_pooled_red', 'bayesreg_mgca_pooled_bcp']:
             statevars = cfg.psm.bayesreg_mgca.psm_required_variables
             psm_avg = 'multiyear'
         else:

--- a/misc/build_ye_file.py
+++ b/misc/build_ye_file.py
@@ -200,6 +200,12 @@ def main(cfgin=None, config_path=None):
         elif psm_key == 'bayesreg_d18o_ruberwhite':
             statevars = cfg.psm.bayesreg_d18o.psm_required_variables
             psm_avg = 'multiyear'
+        elif psm_key in ['bayesreg_mgca_pachyderma_red', 'bayesreg_mgca_pachyderma_bcp',
+                         'bayesreg_mgca_bulloides_red', 'bayesreg_mgca_bulloides_bcp',
+                         'bayesreg_mgca_sacculifer_red', 'bayesreg_mgca_sacculifer_bcp',
+                         'bayesreg_mgca_ruberwhite_red', 'bayesreg_mgca_ruberwhite_bcp']:
+            statevars = cfg.psm.bayesreg_mgca.psm_required_variables
+            psm_avg = 'multiyear'
         else:
             raise SystemExit
 


### PR DESCRIPTION
Adds a preliminary PSM for Mg/Ca marine sediment proxies using the `baymagpy` package. Suggest squashed merge. This is an updated pull request from https://github.com/modons/LMR/pull/27. This current branch was rebased onto updates and should be easier to merge into `production_develop`.

To use this you'll need the `baymagpy` package installed. It's currently under development. You can install the package with conda:

    conda install baymagpy -c sbmalev

You may get a warning about installing the `gsw` package. This requires you to have the conda-forge channel configured (https://conda-forge.org/). You can install `gsw` manually with:

    conda install -c conda-forge gsw

Be warned, `baymagpy` is about 200 mb of ocean chemistry. It's a big download for a package.
