### PR TITLE
Keep the record if its substitute is not loaded

### DIFF
--- a/LMR_proxy_preprocess.py
+++ b/LMR_proxy_preprocess.py
@@ -1973,16 +1973,22 @@ def merge_dicts_to_dataframes(proxy_def, ncdc_dict, pages2kv2_dict, meta_outfile
 
         # numpy array containing names of proxy records to eliminate
         toflush = dupes['Record_To_Eliminate'].values
+        tokeep = dupes['Corresponding_Record_To_Keep'].values
 
         for siteID in list(merged_dict.keys()):
             if siteID in toflush:
-                try:
-                    del merged_dict[siteID]
-                    print(' -- deleting: %s' % siteID)
-                    dupecount += 1
-                except KeyError:
-                    print(' -- not found: %s' % siteID)
-                    pass
+                idx = list(toflush).index(siteID)
+                sub_siteID = tokeep[idx]
+                if sub_siteID in list(merged_dict.keys()):
+                    # delete record only when the substitute is loaded
+                    try:
+                        del merged_dict[siteID]
+                        #  print(' -- deleting: %s' % siteID)
+                        print(f' -- deleting: {siteID}, using: {sub_siteID}')
+                        dupecount += 1
+                    except KeyError:
+                        print(' -- not found: %s' % siteID)
+                        pass
 
     print(' ')
     print('----------------------------------------------------------------------')


### PR DESCRIPTION
This commit is to fix the issue that records listed in `Proxy_Duplicates_PAGES2kv2_NCDC_LMRv1.0.0.xlsx` will be deleted regardless of other settings, even when `include_NCDC = False` and there is no substitute being loaded.

A condition is added to check if the substitute listed in `Proxy_Duplicates_PAGES2kv2_NCDC_LMRv1.0.0.xlsx` has been loaded.
If so, then the target record will be deleted as before; if not, then we should keep the target record.
